### PR TITLE
Copy parameters when specialising type...

### DIFF
--- a/graph/test/main.c
+++ b/graph/test/main.c
@@ -5,4 +5,4 @@
 #include "test_srt.c"
 #include "test_graph.c"
 
-TEST_MAIN(test_loader, test_jack_bindings, test_srt, test_srt_fake_elem, test_graph)
+TEST_MAIN(test_loader, test_specialisation_copies_params, test_jack_bindings, test_srt, test_srt_fake_elem, test_graph)


### PR DESCRIPTION
so if the caller drops them on the floor, we're still good.