### PR TITLE
Fix some silly mistakes that have crept into rage since last attempt to use in anger

### DIFF
--- a/elements/persistence/persistence.c
+++ b/elements/persistence/persistence.c
@@ -221,6 +221,9 @@ static sf_count_t read_prep_sndfile(
         sndfile_status * const s, char const * const path, size_t pos,
         uint32_t to_read, float * interleaved_buffer) {
     if (file_path_changed(s, path)) {
+        // FIXME: URGENT if we open a file with a different number of channels
+        // we will have a terrible day tracking down the ensuing memory
+        // corruption!
         s->sf = sf_open(path, SFM_READ, &s->sf_info);
     }
     // FIXME: may fail (also could be more efficient)

--- a/elements/persistence/persistence.c
+++ b/elements/persistence/persistence.c
@@ -206,7 +206,7 @@ void elem_process(rage_ElementState * data, rage_TransportState const transport_
 
 // FIXME: doesn't handle mode switching with same path, also could do more
 static bool file_path_changed(sndfile_status * const s, char const * const path) {
-    if (strcmp(path, s->open_path)) {
+    if (s->open_path == NULL || strcmp(path, s->open_path)) {
         if (s->sf != NULL) {
             sf_close(s->sf);
         }

--- a/graph/src/proc_block.c
+++ b/graph/src/proc_block.c
@@ -25,6 +25,7 @@ rage_NewProcBlock rage_proc_block_new(uint32_t sample_rate) {
     } else {
         rage_ProcBlock * pb = malloc(sizeof(rage_ProcBlock));
         pb->jack_binding = RAGE_SUCCESS_VALUE(njb);
+        pb->sample_rate = sample_rate;
         // FIXME: FIXED PERIOD SIZE!!!!!
         // The success value should probably be some kind of handy struct
         pb->convoy = rage_support_convoy_new(1024, countdown);


### PR DESCRIPTION
It needs more tests (especially with all the soft realtime stuff).

Spent absolutely ages tracking down that I'd loaded a 2 channel file with a 1 channel element, which caused memory corruption. The error should come out earlier, I've plonked down a fixme for it, but maybe there should be an issue for it. Really does need looking at.