### PR TITLE
Trigger preparation "immediately" when mounting whilst running

### DIFF
--- a/graph/test/test_srt.c
+++ b/graph/test/test_srt.c
@@ -128,11 +128,11 @@ static rage_Error test_srt_fake_elem() {
         .state = &fes};
     rage_Countdown * countdown = rage_countdown_new(0);
     rage_SupportConvoy * convoy = rage_support_convoy_new(1024, countdown);
+    rage_Error err = rage_support_convoy_start(convoy);
     rage_SupportTruck * truck = rage_support_convoy_mount(
         convoy, &fake_elem, prep_view, clean_view);
     // FIXME: ATM don't know (without our sem) when initial prep is done (which
     // is dodgy)
-    rage_Error err = rage_support_convoy_start(convoy);
     rage_Error assertion_err = RAGE_OK;
     if (!RAGE_FAILED(err)) {
         assertion_err = counter_checks(&sync_sem, &fes, 1, 0);

--- a/graph/test/test_srt.c
+++ b/graph/test/test_srt.c
@@ -115,7 +115,7 @@ static rage_Error counter_checks(
     return RAGE_OK;
 }
 
-rage_Error test_srt_fake_elem() {
+static rage_Error test_srt_fake_elem() {
     sem_t sync_sem;
     sem_init(&sync_sem, 0, 0);
     rage_ElementState fes = {

--- a/langext/include/countdown.h
+++ b/langext/include/countdown.h
@@ -28,6 +28,6 @@ rage_Error rage_countdown_timed_wait(rage_Countdown * c, unsigned millis);
  */
 int rage_countdown_add(rage_Countdown * c, int delta);
 /*
- * Unblock a wait without changing the countdown value.
+ * Reset the countdown and release waiter, returns previous value.
  */
-void rage_countdown_unblock_wait(rage_Countdown * c);
+int rage_countdown_unblock_wait(rage_Countdown * c);

--- a/langext/src/countdown.c
+++ b/langext/src/countdown.c
@@ -49,6 +49,10 @@ int rage_countdown_add(rage_Countdown * c, int delta) {
     return val;
 }
 
-void rage_countdown_unblock_wait(rage_Countdown * c) {
-    sem_post(&c->sig);
+int rage_countdown_unblock_wait(rage_Countdown * c) {
+    int val = atomic_exchange(&c->counter, 0);
+    if (val != 0) {
+        sem_post(&c->sig);
+    }
+    return val;
 }


### PR DESCRIPTION
It would have got there in the end, but it was waiting for UINT32_MAX ms before the preparation loop would be rerun.

p.s. with this you can get noise from the haskell