### PR TITLE
Fix all the things valgrind's memcheck throws up from the tests

### DIFF
--- a/elements/persistence/persistence.c
+++ b/elements/persistence/persistence.c
@@ -153,8 +153,9 @@ void elem_free(rage_ElementState * ad) {
     }
     free(ad->rec_buffs);
     free(ad->play_buffs);
-    sndfile_status_destroy(&ad->sndfile);
+    free(ad->interleaved_buffer);
     free(ad->rb_vec);
+    sndfile_status_destroy(&ad->sndfile);
     free(ad);
 }
 

--- a/elements/persistence/test_persistence.c
+++ b/elements/persistence/test_persistence.c
@@ -42,6 +42,7 @@ static rage_Error test_pause_silent() {
     rage_element_process(te.elem, RAGE_TRANSPORT_STOPPED, te.elem_frame_size, &ports);
     rage_Error rv = check_outs_silent(&ports, te.cet->spec.inputs.len, te.elem_frame_size);
     free_out_buffers(&ports, te.cet->spec.inputs.len);
+    rage_ports_free(ports);
     free_test_elem(te);
     return rv;
 }

--- a/graph/include/proc_block.h
+++ b/graph/include/proc_block.h
@@ -8,7 +8,8 @@ typedef RAGE_OR_ERROR(rage_ProcBlock *) rage_NewProcBlock;
 typedef struct rage_Harness rage_Harness;
 typedef RAGE_OR_ERROR(rage_Harness *) rage_MountResult;
 
-rage_NewProcBlock rage_proc_block_new(uint32_t sample_rate);
+rage_NewProcBlock rage_proc_block_new(
+    uint32_t sample_rate, rage_TransportState transp_state);
 void rage_proc_block_free(rage_ProcBlock * pb);
 
 rage_Error rage_proc_block_start(rage_ProcBlock * pb);

--- a/graph/include/srt.h
+++ b/graph/include/srt.h
@@ -7,7 +7,9 @@
 typedef struct rage_SupportConvoy rage_SupportConvoy;
 typedef struct rage_SupportTruck rage_SupportTruck;
 
-rage_SupportConvoy * rage_support_convoy_new(uint32_t period_size, rage_Countdown * countdown);
+rage_SupportConvoy * rage_support_convoy_new(
+    uint32_t period_size, rage_Countdown * countdown,
+    rage_TransportState transp_state);
 void rage_support_convoy_free(rage_SupportConvoy * convoy);
 
 rage_Error rage_support_convoy_start(rage_SupportConvoy * convoy);

--- a/graph/src/graph.c
+++ b/graph/src/graph.c
@@ -8,7 +8,7 @@ struct rage_Graph {
 };
 
 rage_NewGraph rage_graph_new(uint32_t sample_rate) {
-    rage_NewProcBlock npb = rage_proc_block_new(sample_rate);
+    rage_NewProcBlock npb = rage_proc_block_new(sample_rate, RAGE_TRANSPORT_STOPPED);
     if (RAGE_FAILED(npb)) {
         return RAGE_FAILURE_CAST(rage_NewGraph, npb);
     }

--- a/graph/src/loader.c
+++ b/graph/src/loader.c
@@ -152,10 +152,9 @@ rage_ElementNewResult rage_element_new(
         sample_rate, cet->params);
     if (RAGE_FAILED(new_state))
         return RAGE_FAILURE_CAST(rage_ElementNewResult, new_state);
-    void * state = RAGE_SUCCESS_VALUE(new_state);
     rage_Element * const elem = malloc(sizeof(rage_Element));
     elem->cet = cet;
-    elem->state = state;
+    elem->state = RAGE_SUCCESS_VALUE(new_state);
     return RAGE_SUCCESS(rage_ElementNewResult, elem);
 }
 

--- a/graph/src/proc_block.c
+++ b/graph/src/proc_block.c
@@ -23,7 +23,8 @@ struct rage_Harness {
     rage_ProcBlockViews views;
 };
 
-rage_NewProcBlock rage_proc_block_new(uint32_t sample_rate) {
+rage_NewProcBlock rage_proc_block_new(
+        uint32_t sample_rate, rage_TransportState transp_state) {
     rage_Countdown * countdown = rage_countdown_new(0);
     rage_NewJackBinding njb = rage_jack_binding_new(countdown, sample_rate);
     if (RAGE_FAILED(njb)) {
@@ -35,7 +36,7 @@ rage_NewProcBlock rage_proc_block_new(uint32_t sample_rate) {
         pb->sample_rate = sample_rate;
         // FIXME: FIXED PERIOD SIZE!!!!!
         // The success value should probably be some kind of handy struct
-        pb->convoy = rage_support_convoy_new(1024, countdown);
+        pb->convoy = rage_support_convoy_new(1024, countdown, transp_state);
         pb->countdown = countdown;
         return RAGE_SUCCESS(rage_NewProcBlock, pb);
     }

--- a/graph/src/srt.c
+++ b/graph/src/srt.c
@@ -35,10 +35,13 @@ struct rage_SupportConvoy {
     rage_TransportState transport_state;
 };
 
-rage_SupportConvoy * rage_support_convoy_new(uint32_t period_size, rage_Countdown * countdown) {
+rage_SupportConvoy * rage_support_convoy_new(
+        uint32_t period_size, rage_Countdown * countdown,
+        rage_TransportState transp_state) {
     rage_SupportConvoy * convoy = malloc(sizeof(rage_SupportConvoy));
     convoy->running = false;
     convoy->period_size = period_size;
+    convoy->transport_state = transp_state;
     convoy->invalid_after = UINT64_MAX;
     convoy->countdown = countdown;
     // FIXME: can in theory fail

--- a/graph/test/test_srt.c
+++ b/graph/test/test_srt.c
@@ -9,7 +9,8 @@ rage_Error test_srt() {
         return RAGE_FAILURE_CAST(rage_Error, nte);
     rage_TestElem te = RAGE_SUCCESS_VALUE(nte);
     rage_Countdown * countdown = rage_countdown_new(0);
-    rage_SupportConvoy * convoy = rage_support_convoy_new(1024, countdown);
+    rage_SupportConvoy * convoy = rage_support_convoy_new(
+        1024, countdown, RAGE_TRANSPORT_STOPPED);
     rage_SupportTruck * truck = rage_support_convoy_mount(convoy, te.elem, NULL, NULL);
     rage_Error err = rage_support_convoy_start(convoy);
     if (!RAGE_FAILED(err)) {
@@ -108,7 +109,8 @@ static rage_Error test_srt_fake_elem() {
         .cet = &fake_concrete_type,
         .state = &fes};
     rage_Countdown * countdown = rage_countdown_new(0);
-    rage_SupportConvoy * convoy = rage_support_convoy_new(1024, countdown);
+    rage_SupportConvoy * convoy = rage_support_convoy_new(
+        1024, countdown, RAGE_TRANSPORT_STOPPED);
     rage_Error err = rage_support_convoy_start(convoy);
     if (!RAGE_FAILED(err)) {
         rage_InitialisedInterpolator ii = rage_interpolator_new(&empty_tupledef, &ts, 44100, 2);

--- a/types/src/atoms.c
+++ b/types/src/atoms.c
@@ -14,8 +14,7 @@ rage_Atom * rage_tuple_copy(rage_TupleDef const * const td, rage_Atom const * co
                 copy[i] = orig[i];
                 break;
             case RAGE_ATOM_STRING:
-                copy[i].s = malloc(strlen(orig[i].s));
-                strcpy(copy[i].s, orig[i].s);
+                copy[i].s = strdup(orig[i].s);
                 break;
         }
     }

--- a/types/src/interpolation.c
+++ b/types/src/interpolation.c
@@ -301,6 +301,7 @@ static void rage_finalise_timeseries_change(void * p) {
     rage_countdown_timed_wait(tsc->fs->c, 1000); // FIXME: ERROR HANDLING!
     sem_post(tsc->change_sem);
     frameseries_free(tsc->type, tsc->fs);
+    free(tsc);
 }
 
 rage_Finaliser * rage_interpolator_change_timeseries(


### PR DESCRIPTION
There wasn't a massive amount really, but there was 1 potential corruption so maybe that was what was upsetting things?

Should CI running the tool at some point really.