### PR TITLE
Switch off the anonymous union flattening trick for haskell wrapper...

### DIFF
--- a/graph/include/loader.h
+++ b/graph/include/loader.h
@@ -13,10 +13,7 @@ typedef struct rage_ElementKind rage_ElementKind;
 typedef struct {
     rage_ElementType * type;
     rage_Atom ** params;
-    union {
-        rage_InstanceSpec;
-        rage_InstanceSpec spec;
-    };
+    RAGE_ANON_UNION(rage_InstanceSpec, spec);
 } rage_ConcreteElementType;
 
 typedef struct {

--- a/graph/include/loader.h
+++ b/graph/include/loader.h
@@ -13,7 +13,7 @@ typedef struct rage_ElementKind rage_ElementKind;
 typedef struct {
     rage_ElementType * type;
     rage_Atom ** params;
-    RAGE_ANON_UNION(rage_InstanceSpec, spec);
+    RAGE_EMBED_STRUCT(rage_InstanceSpec, spec);
 } rage_ConcreteElementType;
 
 typedef struct {

--- a/graph/src/buffer_pile.c
+++ b/graph/src/buffer_pile.c
@@ -1,13 +1,11 @@
 #include "buffer_pile.h"
+#include "macros.h"
 #include <stdlib.h>
 
 struct rage_BufferAllocs {
     rage_BufferAllocs * next;
     rage_BufferAllocs * prev;
-    union {
-        rage_BuffersInfo;
-        rage_BuffersInfo info;
-    };
+    RAGE_ANON_UNION(rage_BuffersInfo, info);
 };
 
 rage_BufferAllocs * rage_buffer_allocs_new(size_t buffer_size) {

--- a/graph/src/buffer_pile.c
+++ b/graph/src/buffer_pile.c
@@ -5,7 +5,7 @@
 struct rage_BufferAllocs {
     rage_BufferAllocs * next;
     rage_BufferAllocs * prev;
-    RAGE_ANON_UNION(rage_BuffersInfo, info);
+    RAGE_EMBED_STRUCT(rage_BuffersInfo, info);
 };
 
 rage_BufferAllocs * rage_buffer_allocs_new(size_t buffer_size) {

--- a/graph/src/jack_bindings.c
+++ b/graph/src/jack_bindings.c
@@ -13,7 +13,7 @@ struct rage_BackendState {
     rage_JackPorts input_ports;
     rage_JackPorts output_ports;
     rage_BackendInterface backend;
-    RAGE_ANON_UNION(rage_BackendConfig, conf);
+    RAGE_EMBED_STRUCT(rage_BackendConfig, conf);
 };
 
 void rage_jack_backend_get_buffers(

--- a/graph/src/jack_bindings.c
+++ b/graph/src/jack_bindings.c
@@ -13,10 +13,7 @@ struct rage_BackendState {
     rage_JackPorts input_ports;
     rage_JackPorts output_ports;
     rage_BackendInterface backend;
-    union {
-        rage_BackendConfig;
-        rage_BackendConfig conf;
-    };
+    RAGE_ANON_UNION(rage_BackendConfig, conf);
 };
 
 void rage_jack_backend_get_buffers(

--- a/graph/src/proc_block.c
+++ b/graph/src/proc_block.c
@@ -17,7 +17,7 @@ typedef struct {
 struct rage_Harness {
     rage_Element * elem;
     // FIXME: Don't actually need a ports per elem (but 1 of the largest size)?
-    RAGE_ANON_UNION(rage_Ports, ports);
+    RAGE_EMBED_STRUCT(rage_Ports, ports);
     rage_SupportTruck * truck;
     rage_Interpolator ** interpolators;
     rage_ProcBlockViews views;

--- a/graph/src/proc_block.c
+++ b/graph/src/proc_block.c
@@ -17,10 +17,7 @@ typedef struct {
 struct rage_Harness {
     rage_Element * elem;
     // FIXME: Don't actually need a ports per elem (but 1 of the largest size)?
-    union {
-        rage_Ports;
-        rage_Ports ports;
-    };
+    RAGE_ANON_UNION(rage_Ports, ports);
     rage_SupportTruck * truck;
     rage_Interpolator ** interpolators;
     rage_ProcBlockViews views;

--- a/haskwrap/include/wrappers.h
+++ b/haskwrap/include/wrappers.h
@@ -1,4 +1,5 @@
 #pragma once
+#define RAGE_DISABLE_ANON_UNIONS 1
 #include "loader.h"
 #include "graph.h"
 

--- a/langext/include/macros.h
+++ b/langext/include/macros.h
@@ -90,6 +90,13 @@ typedef enum {
         return new_array; \
     }
 
+/*
+ * RAGE internally uses structs wrapped in anonymous unions to reduce
+ * intermediary dots in accesors (without losing the ability to take a pointer
+ * to the sub struct).
+ * However should you be using a tool (e.g. c2hs) that doesn't understand this
+ * then #define RAGE_DISABLE_ANON_UNIONS before including.
+ */
 #ifdef RAGE_DISABLE_ANON_UNIONS
 #define RAGE_EMBED_STRUCT(t, v) t v
 #else

--- a/langext/include/macros.h
+++ b/langext/include/macros.h
@@ -91,7 +91,7 @@ typedef enum {
     }
 
 #ifdef RAGE_DISABLE_ANON_UNIONS
-#define RAGE_ANON_UNION(t, v) t v
+#define RAGE_EMBED_STRUCT(t, v) t v
 #else
-#define RAGE_ANON_UNION(t, v) union {t; t v;}
+#define RAGE_EMBED_STRUCT(t, v) union {t; t v;}
 #endif

--- a/langext/include/macros.h
+++ b/langext/include/macros.h
@@ -89,3 +89,9 @@ typedef enum {
         } \
         return new_array; \
     }
+
+#ifdef RAGE_DISABLE_ANON_UNIONS
+#define RAGE_ANON_UNION(t, v) t v
+#else
+#define RAGE_ANON_UNION(t, v) union {t; t v;}
+#endif


### PR DESCRIPTION
since it doesn't play nicely with c2hs.

The macro could probably do with a better name, but I can't think of one right now.