### PR TITLE
Add additional wrappers for connect methods

### DIFF
--- a/haskwrap/include/wrappers.h
+++ b/haskwrap/include/wrappers.h
@@ -13,6 +13,14 @@ rage_NewGraphNode * rage_graph_add_node_hs(
     rage_Graph * g, rage_ConcreteElementType * cet,
     rage_TimeSeries const * ts);
 rage_Error * rage_graph_transport_seek_hs(rage_Graph * g, rage_Time const * t);
+rage_Error * rage_graph_connect_hs(
+    rage_Graph * g,
+    rage_GraphNode * source, uint32_t source_idx,
+    rage_GraphNode * sink, uint32_t sink_idx);
+rage_Error * rage_graph_disconnect_hs(
+    rage_Graph * g,
+    rage_GraphNode * source, uint32_t source_idx,
+    rage_GraphNode * sink, uint32_t sink_idx);
 
 // Wrappers for things that use anonymous unions
 rage_InstanceSpec * rage_cet_get_spec_hs(rage_ConcreteElementType * cet);

--- a/haskwrap/src/wrappers.c
+++ b/haskwrap/src/wrappers.c
@@ -23,6 +23,24 @@ RAGE_HS_STRUCT_WRAPPER(
     rage_Error, (rage_Graph * g, rage_Time const * t),
     rage_graph_transport_seek, (g, t))
 
+RAGE_HS_STRUCT_WRAPPER(
+    rage_Error,
+    (
+        rage_Graph * g,
+        rage_GraphNode * source, uint32_t source_idx,
+        rage_GraphNode * sink, uint32_t sink_idx
+    ),
+    rage_graph_connect, (g, source, source_idx, sink, sink_idx))
+
+RAGE_HS_STRUCT_WRAPPER(
+    rage_Error,
+    (
+        rage_Graph * g,
+        rage_GraphNode * source, uint32_t source_idx,
+        rage_GraphNode * sink, uint32_t sink_idx
+    ),
+    rage_graph_disconnect, (g, source, source_idx, sink, sink_idx))
+
 #undef RAGE_HS_STRUCT_WRAPPER
 
 rage_InstanceSpec * rage_cet_get_spec_hs(rage_ConcreteElementType * cet) {


### PR DESCRIPTION
The haskell needs to call them, and can't cope with being returned structs (as noted previously).