### PR TITLE
Transactional connecting

### DIFF
--- a/example/main.c
+++ b/example/main.c
@@ -156,14 +156,16 @@ int main() {
         bits.graph, bits.st_amp, &amp_ts);
     RAGE_ABORT_ON_FAILURE(new_node, 6);
     rage_GraphNode * anode = RAGE_SUCCESS_VALUE(new_node);
+    rage_ConTrans * ct = rage_graph_con_trans_start(bits.graph);
     for (uint32_t chan = 0; chan < 2; chan++) {
         rage_Error connect_result = rage_graph_connect(
-            bits.graph, pnode, chan, anode, chan);
+            ct, pnode, chan, anode, chan);
         RAGE_ABORT_ON_FAILURE(connect_result, 7 + chan);
         connect_result = rage_graph_connect(
-            bits.graph, anode, chan, NULL, chan);
+            ct, anode, chan, NULL, chan);
         RAGE_ABORT_ON_FAILURE(connect_result, 9 + chan);
     }
+    rage_graph_con_trans_commit(ct);
     printf("Node added\n");
     sleep(5);
     printf("Recording...\n");

--- a/graph/include/con_trans.h
+++ b/graph/include/con_trans.h
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef struct rage_ConTrans rage_ConTrans;

--- a/graph/include/depmap.h
+++ b/graph/include/depmap.h
@@ -14,16 +14,21 @@ typedef struct rage_ConnTerminals {
     struct rage_ConnTerminals * next;
 } rage_ConnTerminals;
 
-typedef struct rage_DepMap rage_DepMap;
+typedef struct rage_Connection {
+    rage_ConnTerminal src;
+    rage_ConnTerminal sink;
+} rage_Connection;
+
+typedef RAGE_ARRAY(rage_Connection) rage_DepMap;
 
 typedef RAGE_OR_ERROR(rage_DepMap *) rage_ExtDepMap;
 
 rage_DepMap * rage_depmap_new();
 void rage_depmap_free(rage_DepMap * dm);
 rage_ExtDepMap rage_depmap_connect(
-    rage_DepMap * dm, rage_ConnTerminal input, rage_ConnTerminal output);
-rage_DepMap * rage_depmap_disconnect(
-    rage_DepMap * dm, rage_ConnTerminal input, rage_ConnTerminal output);
+    rage_DepMap const * dm, rage_ConnTerminal input, rage_ConnTerminal output);
+rage_ExtDepMap rage_depmap_disconnect(
+    rage_DepMap const * dm, rage_ConnTerminal input, rage_ConnTerminal output);
 
 rage_MaybeConnTerminal rage_depmap_input_for(
     rage_DepMap const * dm, rage_ConnTerminal const output);
@@ -37,10 +42,6 @@ rage_ConnTerminals * rage_depmap_outputs(
 
 void rage_conn_terms_free(rage_ConnTerminals * ct);
 
-rage_DepMap * rage_remove_connections_for(
+// This is an in-place operation:
+void rage_remove_connections_for(
     rage_DepMap * initial, rage_Harness * tgt);
-
-typedef const struct rage_DepMap rage_DepMapIter;
-rage_DepMapIter * rage_depmap_iter(rage_DepMap const * dm);
-rage_DepMapIter * rage_depmap_iter_item(
-    rage_DepMapIter * dmi, rage_ConnTerminal * src, rage_ConnTerminal * sink);

--- a/graph/include/graph.h
+++ b/graph/include/graph.h
@@ -3,7 +3,7 @@
 #include "atoms.h"
 #include "loader.h"
 #include "binding_interface.h"
-#include "proc_block.h"
+#include "con_trans.h"
 
 typedef struct rage_Graph rage_Graph;
 typedef RAGE_OR_ERROR(rage_Graph *) rage_NewGraph;

--- a/graph/include/graph.h
+++ b/graph/include/graph.h
@@ -3,6 +3,7 @@
 #include "atoms.h"
 #include "loader.h"
 #include "binding_interface.h"
+#include "proc_block.h"
 
 typedef struct rage_Graph rage_Graph;
 typedef RAGE_OR_ERROR(rage_Graph *) rage_NewGraph;
@@ -24,11 +25,14 @@ rage_Finaliser * rage_graph_update_node(
         rage_TimeSeries const * const ts);
 void rage_graph_remove_node(rage_Graph * g, rage_GraphNode * n);
 
+rage_ConTrans * rage_graph_con_trans_start(rage_Graph * g);
+void rage_graph_con_trans_commit(rage_ConTrans * ct);
+void rage_graph_con_trans_abort(rage_ConTrans * ct);
 rage_Error rage_graph_connect(
-    rage_Graph * g,
+    rage_ConTrans * ct,
     rage_GraphNode * source, uint32_t source_idx,
     rage_GraphNode * sink, uint32_t sink_idx);
 rage_Error rage_graph_disconnect(
-    rage_Graph * g,
+    rage_ConTrans * ct,
     rage_GraphNode * source, uint32_t source_idx,
     rage_GraphNode * sink, uint32_t sink_idx);

--- a/graph/include/proc_block.h
+++ b/graph/include/proc_block.h
@@ -3,6 +3,7 @@
 #include "loader.h"
 #include "time_series.h"
 #include "binding_interface.h"
+#include "con_trans.h"
 
 typedef struct rage_ProcBlock rage_ProcBlock;
 typedef struct rage_Harness rage_Harness;
@@ -28,8 +29,6 @@ rage_Finaliser * rage_harness_set_time_series(
 
 void rage_proc_block_set_transport_state(rage_ProcBlock * pb, rage_TransportState state);
 rage_Error rage_proc_block_transport_seek(rage_ProcBlock * pb, rage_FrameNo target);
-
-typedef struct rage_ConTrans rage_ConTrans;
 
 rage_ConTrans * rage_proc_block_con_trans_start(rage_ProcBlock * pb);
 void rage_proc_block_con_trans_commit(rage_ConTrans * trans);

--- a/graph/include/proc_block.h
+++ b/graph/include/proc_block.h
@@ -29,12 +29,17 @@ rage_Finaliser * rage_harness_set_time_series(
 void rage_proc_block_set_transport_state(rage_ProcBlock * pb, rage_TransportState state);
 rage_Error rage_proc_block_transport_seek(rage_ProcBlock * pb, rage_FrameNo target);
 
+typedef struct rage_ConTrans rage_ConTrans;
+
+rage_ConTrans * rage_proc_block_con_trans_start(rage_ProcBlock * pb);
+void rage_proc_block_con_trans_commit(rage_ConTrans * trans);
+void rage_proc_block_con_trans_abort(rage_ConTrans * trans);
 rage_Error rage_proc_block_connect(
-    rage_ProcBlock * pb,
+    rage_ConTrans * trans,
     rage_Harness * source, uint32_t source_idx,
     rage_Harness * sink, uint32_t sink_idx);
 rage_Error rage_proc_block_disconnect(
-    rage_ProcBlock * pb,
+    rage_ConTrans * trans,
     rage_Harness * source, uint32_t source_idx,
     rage_Harness * sink, uint32_t sink_idx);
 

--- a/graph/src/depmap.c
+++ b/graph/src/depmap.c
@@ -30,7 +30,7 @@ rage_ExtDepMap rage_depmap_connect(
     } else {
         rage_DepMap * new_dm = malloc(sizeof(rage_DepMap));
         new_dm->len = dm->len + 1;
-        new_dm->items = calloc(sizeof(rage_Connection), new_dm->len);
+        new_dm->items = calloc(new_dm->len, sizeof(rage_Connection));
         memcpy(new_dm->items, dm->items, sizeof(rage_Connection) * dm->len);
         new_dm->items[dm->len].src = input;
         new_dm->items[dm->len].sink = output;
@@ -46,7 +46,7 @@ rage_ExtDepMap rage_depmap_disconnect(
                 rage_conn_terminal_eq(&dm->items[i].sink, &out)) {
             rage_DepMap * new_dm = malloc(sizeof(rage_DepMap));
             new_dm->len = dm->len - 1;
-            new_dm->items = calloc(sizeof(rage_Connection), new_dm->len);
+            new_dm->items = calloc(new_dm->len, sizeof(rage_Connection));
             memcpy(new_dm->items, dm->items, sizeof(rage_Connection) * i);
             memcpy(new_dm->items, &dm->items[i], sizeof(rage_Connection) * (new_dm->len - i));
             return RAGE_SUCCESS(rage_ExtDepMap, new_dm);

--- a/graph/src/depmap.c
+++ b/graph/src/depmap.c
@@ -1,34 +1,27 @@
 #include "depmap.h"
 
-struct rage_DepMap {
-    rage_ConnTerminal src;
-    rage_ConnTerminal sink;
-    struct rage_DepMap * next;
-};
-
 static bool rage_conn_terminal_eq(
         rage_ConnTerminal const * a, rage_ConnTerminal const * b) {
     return a->harness == b->harness && a->idx == b->idx;
 }
 
 rage_DepMap * rage_depmap_new() {
-    return NULL;
+    rage_DepMap * dm = malloc(sizeof(rage_DepMap));
+    dm->len = 0;
+    dm->items = NULL;
+    return dm;
 }
 
 void rage_depmap_free(rage_DepMap * dm) {
-    while (dm != NULL) {
-        rage_DepMap * const nxt = dm->next;
-        free(dm);
-        dm = nxt;
-    }
+    RAGE_ARRAY_FREE(dm);
 }
 
 rage_ExtDepMap rage_depmap_connect(
-        rage_DepMap * dm, rage_ConnTerminal input, rage_ConnTerminal output) {
+        rage_DepMap const * dm, rage_ConnTerminal input, rage_ConnTerminal output) {
     rage_MaybeConnTerminal mct = rage_depmap_input_for(dm, output);
     if (RAGE_IS_JUST(mct)) {
         if (rage_conn_terminal_eq(&RAGE_FROM_JUST(mct), &input)) {
-            return RAGE_SUCCESS(rage_ExtDepMap, dm);
+            return RAGE_FAILURE(rage_ExtDepMap, "Already connected");
         } else {
             return RAGE_FAILURE(
                 rage_ExtDepMap,
@@ -36,50 +29,51 @@ rage_ExtDepMap rage_depmap_connect(
         }
     } else {
         rage_DepMap * new_dm = malloc(sizeof(rage_DepMap));
-        new_dm->next = dm;
-        new_dm->src = input;
-        new_dm->sink = output;
+        new_dm->len = dm->len + 1;
+        new_dm->items = calloc(sizeof(rage_Connection), new_dm->len);
+        memcpy(new_dm->items, dm->items, sizeof(rage_Connection) * dm->len);
+        new_dm->items[dm->len].src = input;
+        new_dm->items[dm->len].sink = output;
         return RAGE_SUCCESS(rage_ExtDepMap, new_dm);
     }
 }
 
-rage_DepMap * rage_depmap_disconnect(
-        rage_DepMap * initial, rage_ConnTerminal in, rage_ConnTerminal out) {
-    rage_DepMap * c, * prev_con = NULL;
-    for (c = initial; c != NULL; c = c->next) {
+rage_ExtDepMap rage_depmap_disconnect(
+        rage_DepMap const * dm, rage_ConnTerminal in, rage_ConnTerminal out) {
+    for (uint32_t i = 0; i < dm->len; i++) {
         if (
-                rage_conn_terminal_eq(&c->src, &in) &&
-                rage_conn_terminal_eq(&c->sink, &out)) {
-            if (prev_con) {
-                prev_con->next = c->next;
-            } else {
-                initial = c->next;
-            }
-            free(c);
-            break;
+                rage_conn_terminal_eq(&dm->items[i].src, &in) &&
+                rage_conn_terminal_eq(&dm->items[i].sink, &out)) {
+            rage_DepMap * new_dm = malloc(sizeof(rage_DepMap));
+            new_dm->len = dm->len - 1;
+            new_dm->items = calloc(sizeof(rage_Connection), new_dm->len);
+            memcpy(new_dm->items, dm->items, sizeof(rage_Connection) * i);
+            memcpy(new_dm->items, &dm->items[i], sizeof(rage_Connection) * (new_dm->len - i));
+            return RAGE_SUCCESS(rage_ExtDepMap, new_dm);
         }
-        prev_con = c;
     }
-    return initial;
+    return RAGE_FAILURE(rage_ExtDepMap, "Were not connected");
 }
 
 rage_MaybeConnTerminal rage_depmap_input_for(
         rage_DepMap const * dm, rage_ConnTerminal const output) {
-    for (; dm != NULL; dm = dm->next) {
-        if (rage_conn_terminal_eq(&dm->sink, &output)) {
-            return (rage_MaybeConnTerminal) RAGE_JUST(dm->src);
+    for (uint32_t i = 0; i < dm->len; i++) {
+        if (rage_conn_terminal_eq(&dm->items[i].sink, &output)) {
+            return (rage_MaybeConnTerminal) RAGE_JUST(dm->items[i].src);
         }
     }
     return (rage_MaybeConnTerminal) RAGE_NOTHING;
 }
 
 typedef RAGE_MAYBE(rage_ConnTerminal const *) rage_MaybeTerminal;
-typedef rage_MaybeTerminal (*rage_dm_match)(rage_DepMap const * dm, rage_ConnTerminal * term);
+typedef rage_MaybeTerminal (*rage_dm_match)(
+    rage_Connection const * conn, rage_ConnTerminal * term);
 
-static rage_ConnTerminals * rage_cons_matching(rage_DepMap const * dm, rage_dm_match match, rage_ConnTerminal term) {
+static rage_ConnTerminals * rage_cons_matching(
+        rage_DepMap const * dm, rage_dm_match match, rage_ConnTerminal term) {
     rage_ConnTerminals * rv = NULL;
-    for (; dm != NULL; dm = dm->next) {
-        rage_MaybeTerminal mt = match(dm, &term);
+    for (uint32_t i = 0; i < dm->len; i++) {
+        rage_MaybeTerminal mt = match(&dm->items[i], &term);
         if (RAGE_IS_JUST(mt)) {
             rage_ConnTerminals * new_term = malloc(sizeof(rage_ConnTerminals));
             new_term->term = *RAGE_FROM_JUST(mt);
@@ -90,9 +84,9 @@ static rage_ConnTerminals * rage_cons_matching(rage_DepMap const * dm, rage_dm_m
     return rv;
 }
 
-static rage_MaybeTerminal rage_outputs_to(rage_DepMap const * dm, rage_ConnTerminal * term) {
-    if (rage_conn_terminal_eq(&dm->src, term)) {
-        return (rage_MaybeTerminal) RAGE_JUST(&dm->sink);
+static rage_MaybeTerminal rage_outputs_to(rage_Connection const * conn, rage_ConnTerminal * term) {
+    if (rage_conn_terminal_eq(&conn->src, term)) {
+        return (rage_MaybeTerminal) RAGE_JUST(&conn->sink);
     }
     return (rage_MaybeTerminal) RAGE_NOTHING;
 }
@@ -102,9 +96,9 @@ rage_ConnTerminals * rage_depmap_outputs_for(
     return rage_cons_matching(dm, rage_outputs_to, input);
 }
 
-static rage_MaybeTerminal rage_output_harness(rage_DepMap const * dm, rage_ConnTerminal * term) {
-    if (dm->src.harness == term->harness) {
-        return (rage_MaybeTerminal) RAGE_JUST(&dm->sink);
+static rage_MaybeTerminal rage_output_harness(rage_Connection const * conn, rage_ConnTerminal * term) {
+    if (conn->src.harness == term->harness) {
+        return (rage_MaybeTerminal) RAGE_JUST(&conn->sink);
     }
     return (rage_MaybeTerminal) RAGE_NOTHING;
 }
@@ -116,9 +110,9 @@ rage_ConnTerminals * rage_depmap_outputs(
         (rage_ConnTerminal) {.harness = (rage_Harness *) h});
 }
 
-static rage_MaybeTerminal rage_input_harness(rage_DepMap const * dm, rage_ConnTerminal * term) {
-    if (dm->sink.harness == term->harness) {
-        return (rage_MaybeTerminal) RAGE_JUST(&dm->src);
+static rage_MaybeTerminal rage_input_harness(rage_Connection const * conn, rage_ConnTerminal * term) {
+    if (conn->sink.harness == term->harness) {
+        return (rage_MaybeTerminal) RAGE_JUST(&conn->src);
     }
     return (rage_MaybeTerminal) RAGE_NOTHING;
 }
@@ -138,33 +132,15 @@ void rage_conn_terms_free(rage_ConnTerminals * ct) {
     }
 }
 
-rage_DepMap * rage_remove_connections_for(
-        rage_DepMap * initial, rage_Harness * tgt) {
-    rage_DepMap * c, * next, * prev_con = NULL;
-    for (c = initial; c != NULL; c = next) {
-        next = c->next;
-        if (c->src.harness == tgt || c->sink.harness == tgt) {
-            if (prev_con) {
-                prev_con->next = c->next;
-            } else {
-                initial = c->next;
-            }
-            free(c);
+void rage_remove_connections_for(
+        rage_DepMap * dm, rage_Harness * tgt) {
+    uint32_t n_matched = 0;
+    for (uint32_t i = 0; i < dm->len; i++) {
+        if (dm->items[i].src.harness == tgt || dm->items[i].sink.harness == tgt) {
+            n_matched++;
         } else {
-            prev_con = c;
+            dm->items[i - n_matched] = dm->items[i];
         }
     }
-    return initial;
-}
-
-rage_DepMapIter * rage_depmap_iter(rage_DepMap const * dm) {
-    return dm;
-}
-
-rage_DepMapIter * rage_depmap_iter_item(
-        rage_DepMapIter * dmi,
-        rage_ConnTerminal * src, rage_ConnTerminal * sink) {
-    *src = dmi->src;
-    *sink = dmi->sink;
-    return dmi->next;
+    dm->len -= n_matched;
 }

--- a/graph/src/graph.c
+++ b/graph/src/graph.c
@@ -91,22 +91,34 @@ static rage_Harness * rage_graph_get_harness(rage_GraphNode * n) {
     return (n == NULL) ? NULL : n->harness;
 }
 
+rage_ConTrans * rage_graph_con_trans_start(rage_Graph * g) {
+    return rage_proc_block_con_trans_start(g->pb);
+}
+
+void rage_graph_con_trans_commit(rage_ConTrans * ct) {
+    rage_proc_block_con_trans_commit(ct);
+}
+
+void rage_graph_con_trans_abort(rage_ConTrans * ct) {
+    rage_proc_block_con_trans_abort(ct);
+}
+
 rage_Error rage_graph_connect(
-        rage_Graph * g,
+        rage_ConTrans * ct,
         rage_GraphNode * source, uint32_t source_idx,
         rage_GraphNode * sink, uint32_t sink_idx) {
     return rage_proc_block_connect(
-        g->pb,
+        ct,
         rage_graph_get_harness(source), source_idx,
         rage_graph_get_harness(sink), sink_idx);
 }
 
 rage_Error rage_graph_disconnect(
-        rage_Graph * g,
+        rage_ConTrans * ct,
         rage_GraphNode * source, uint32_t source_idx,
         rage_GraphNode * sink, uint32_t sink_idx) {
     return rage_proc_block_disconnect(
-        g->pb,
+        ct,
         rage_graph_get_harness(source), source_idx,
         rage_graph_get_harness(sink), sink_idx);
 }

--- a/graph/src/proc_block.c
+++ b/graph/src/proc_block.c
@@ -576,23 +576,39 @@ static void rage_pb_init_all_buffers(rage_ProcBlock const * pb, rage_RtBits * rt
     memcpy(&rt->all_buffers[pb->min_dynamic_buffer], buffer_info->buffers, buffer_info->n_buffers * sizeof(void *));
 }
 
-static rage_Error rage_proc_block_recalculate_routing(rage_ProcBlock * pb) {
-    rage_RtBits const * old_rt = rage_rt_crit_update_start(pb->syncy);
-    rage_OrderedProcSteps ops = rage_order_proc_steps(&old_rt->steps, pb->cons);
-    if (RAGE_FAILED(ops)) {
-        rage_rt_crit_update_abort(pb->syncy);
-        return RAGE_FAILURE_CAST(rage_Error, ops);
+struct rage_ConTrans {
+    rage_ProcBlock * pb;
+    rage_DepMap * cons;
+    rage_RtBits const * old_rt;
+    rage_ProcSteps steps;
+    uint32_t highest_assignment;
+    bool empty_trans;
+};
+
+rage_ConTrans * rage_proc_block_con_trans_start(rage_ProcBlock * pb) {
+    rage_ConTrans * ct = malloc(sizeof(rage_ConTrans));
+    ct->pb = pb;
+    ct->cons = pb->cons;
+    ct->old_rt = rage_rt_crit_update_start(pb->syncy);
+    ct->steps = ct->old_rt->steps;
+    ct->empty_trans = true;
+    return ct;
+}
+
+void rage_proc_block_con_trans_commit(rage_ConTrans * trans) {
+    if (trans->empty_trans) {
+        free(trans);
+        return;
     }
-    rage_ProcSteps os = RAGE_SUCCESS_VALUE(ops);
     rage_AssignedConnection * assigned_cons = NULL;
-    uint32_t highest_assignment = pb->min_dynamic_buffer - 1;
+    uint32_t highest_assignment = trans->pb->min_dynamic_buffer - 1;
     rage_ExternalOut * ext_outs = NULL;
-    for (uint32_t i = 0; i < os.len; i++) {
-        rage_AssignedConnection * step_cons = rage_cons_from(pb->cons, os.items[i].harness);
+    for (uint32_t i = 0; i < trans->steps.len; i++) {
+        rage_AssignedConnection * step_cons = rage_cons_from(trans->cons, trans->steps.items[i].harness);
         while (step_cons != NULL) {
             rage_AssignedConnection * const c = step_cons;
             step_cons = step_cons->next;
-            rage_ExternalOut * ext = rage_get_ext_outs(pb->be_ports.inputs.len + 2, c);
+            rage_ExternalOut * ext = rage_get_ext_outs(trans->pb->be_ports.inputs.len + 2, c);
             if (ext != NULL) {
                 c->assignment = ext->primary;
                 if (ext->len) {
@@ -603,74 +619,86 @@ static rage_Error rage_proc_block_recalculate_routing(rage_ProcBlock * pb) {
                 }
             } else {
                 c->assignment = rage_lowest_avail_assign(
-                    pb->min_dynamic_buffer, assigned_cons, &highest_assignment);
+                    trans->pb->min_dynamic_buffer, assigned_cons, &highest_assignment);
             }
             c->next = assigned_cons;
             assigned_cons = c;
-            os.items[i].out_buffer_allocs[c->source_idx] = c->assignment;
+            trans->steps.items[i].out_buffer_allocs[c->source_idx] = c->assignment;
             for (rage_ConnTarget * ct = c->con_tgt; ct != NULL; ct = ct->next) {
                 if (ct->tgt_harness == NULL) {  // External connection
                     continue;  // FIXME: should the external and internal connections be mixed up?
                 }
-                uint32_t const step_idx = rage_step_idx(&os, ct->tgt_harness);
-                os.items[step_idx].in_buffer_allocs[ct->tgt_idx] = c->assignment;
+                uint32_t const step_idx = rage_step_idx(&trans->steps, ct->tgt_harness);
+                trans->steps.items[step_idx].in_buffer_allocs[ct->tgt_idx] = c->assignment;
             }
         }
-        assigned_cons = rage_remove_cons_targetted(assigned_cons, os.items[i].harness);
+        assigned_cons = rage_remove_cons_targetted(assigned_cons, trans->steps.items[i].harness);
     }
-    rage_BufferAllocs * const old_allocs = pb->allocs;
-    pb->allocs = rage_buffer_allocs_alloc(
-        pb->allocs, highest_assignment - (pb->min_dynamic_buffer - 1));
+    rage_BufferAllocs * const old_allocs = trans->pb->allocs;
+    trans->pb->allocs = rage_buffer_allocs_alloc(
+        old_allocs, highest_assignment - (trans->pb->min_dynamic_buffer - 1));
     rage_RtBits * new_rt = malloc(sizeof(rage_RtBits));
-    new_rt->transp = old_rt->transp;
-    new_rt->steps = os;
+    new_rt->transp = trans->old_rt->transp;
+    new_rt->steps = trans->steps;
     new_rt->ext_outs = ext_outs;
-    rage_pb_init_all_buffers(pb, new_rt, highest_assignment);
-    rage_RtBits * replaced = rage_rt_crit_update_finish(pb->syncy, new_rt);
+    rage_pb_init_all_buffers(trans->pb, new_rt, highest_assignment);
+    rage_RtBits * replaced = rage_rt_crit_update_finish(trans->pb->syncy, new_rt);
     rage_buffer_allocs_free(old_allocs);
     free(replaced->steps.items);
     free(replaced->all_buffers);
     rage_ext_outs_free(replaced->ext_outs);
     free(replaced);
+    free(trans);
+}
+
+void rage_proc_block_con_trans_abort(rage_ConTrans * ct) {
+    if (!ct->empty_trans) {
+        free(ct->steps.items);
+        rage_depmap_free(ct->cons);
+    }
+    free(ct);
+}
+
+static rage_Error rage_proc_block_recalculate_routing(rage_ConTrans * trans, rage_DepMap * dm) {
+    rage_OrderedProcSteps ops = rage_order_proc_steps(&trans->steps, dm);
+    if (RAGE_FAILED(ops)) {
+        rage_depmap_free(dm);
+        return RAGE_FAILURE_CAST(rage_Error, ops);
+    }
+    if (!trans->empty_trans) {
+        free(trans->steps.items);
+        rage_depmap_free(trans->cons);
+    }
+    trans->empty_trans = false;
+    trans->steps = RAGE_SUCCESS_VALUE(ops);
+    trans->cons = dm;
     return RAGE_OK;
 }
 
 rage_Error rage_proc_block_connect(
-        rage_ProcBlock * pb,
+        rage_ConTrans * trans,
         rage_Harness * source, uint32_t source_idx,
         rage_Harness * sink, uint32_t sink_idx) {
     rage_ConnTerminal in_term = {.harness = source, .idx = source_idx};
     rage_ConnTerminal out_term = {.harness = sink, .idx = sink_idx};
-    rage_ExtDepMap edm = rage_depmap_connect(pb->cons, in_term, out_term);
+    rage_ExtDepMap edm = rage_depmap_connect(trans->cons, in_term, out_term);
     if (RAGE_FAILED(edm)) {
         return RAGE_FAILURE_CAST(rage_Error, edm);
     }
-    rage_DepMap * initial_depmap = pb->cons;
-    pb->cons = RAGE_SUCCESS_VALUE(edm);
-    rage_Error err = rage_proc_block_recalculate_routing(pb);
-    if (RAGE_FAILED(err)) {
-        rage_depmap_free(pb->cons);
-        pb->cons = initial_depmap;
-    } else {
-        rage_depmap_free(initial_depmap);
-    }
-    return err;
+    return rage_proc_block_recalculate_routing(trans, RAGE_SUCCESS_VALUE(edm));
 }
 
 rage_Error rage_proc_block_disconnect(
-        rage_ProcBlock * pb,
+        rage_ConTrans * trans,
         rage_Harness * source, uint32_t source_idx,
         rage_Harness * sink, uint32_t sink_idx) {
     rage_ConnTerminal in_term = {.harness = source, .idx = source_idx};
     rage_ConnTerminal out_term = {.harness = sink, .idx = sink_idx};
-    rage_ExtDepMap edm = rage_depmap_disconnect(pb->cons, in_term, out_term);
+    rage_ExtDepMap edm = rage_depmap_disconnect(trans->cons, in_term, out_term);
     if (RAGE_FAILED(edm)) {
         return RAGE_FAILURE_CAST(rage_Error, edm);
-    } else {
-        rage_depmap_free(pb->cons);
-        pb->cons = RAGE_SUCCESS_VALUE(edm);
-        return rage_proc_block_recalculate_routing(pb);
     }
+    return rage_proc_block_recalculate_routing(trans, RAGE_SUCCESS_VALUE(edm));
 }
 
 rage_BackendConfig rage_proc_block_get_backend_config(rage_ProcBlock * pb) {

--- a/haskwrap/include/wrappers.h
+++ b/haskwrap/include/wrappers.h
@@ -14,11 +14,11 @@ rage_NewGraphNode * rage_graph_add_node_hs(
     rage_TimeSeries const * ts);
 rage_Error * rage_graph_transport_seek_hs(rage_Graph * g, rage_Time const * t);
 rage_Error * rage_graph_connect_hs(
-    rage_Graph * g,
+    rage_ConTrans * g,
     rage_GraphNode * source, uint32_t source_idx,
     rage_GraphNode * sink, uint32_t sink_idx);
 rage_Error * rage_graph_disconnect_hs(
-    rage_Graph * g,
+    rage_ConTrans * g,
     rage_GraphNode * source, uint32_t source_idx,
     rage_GraphNode * sink, uint32_t sink_idx);
 

--- a/haskwrap/src/wrappers.c
+++ b/haskwrap/src/wrappers.c
@@ -26,7 +26,7 @@ RAGE_HS_STRUCT_WRAPPER(
 RAGE_HS_STRUCT_WRAPPER(
     rage_Error,
     (
-        rage_Graph * g,
+        rage_ConTrans * g,
         rage_GraphNode * source, uint32_t source_idx,
         rage_GraphNode * sink, uint32_t sink_idx
     ),
@@ -35,7 +35,7 @@ RAGE_HS_STRUCT_WRAPPER(
 RAGE_HS_STRUCT_WRAPPER(
     rage_Error,
     (
-        rage_Graph * g,
+        rage_ConTrans * g,
         rage_GraphNode * source, uint32_t source_idx,
         rage_GraphNode * sink, uint32_t sink_idx
     ),

--- a/meson.build
+++ b/meson.build
@@ -67,10 +67,11 @@ graph_inc = include_directories('graph/include')
 install_headers(
     'haskwrap/include/wrappers.h',
     'graph/include/graph.h', 'graph/include/loader.h',
-    'graph/include/binding_interface.h', 'types/include/atoms.h',
-    'types/include/element.h', 'types/include/ports.h',
-    'types/include/interpolation.h', 'types/include/chronology.h',
-    'types/include/transport_state.h', 'types/include/time_series.h',
+    'graph/include/binding_interface.h', 'graph/include/con_trans.h',
+    'types/include/atoms.h', 'types/include/element.h',
+    'types/include/ports.h', 'types/include/interpolation.h',
+    'types/include/chronology.h', 'types/include/transport_state.h',
+    'types/include/time_series.h',
     'langext/include/macros.h', 'langext/include/error.h',
     'langext/include/finaliser.h',
     subdir: 'rage')


### PR DESCRIPTION
Allow several connection changes to be made transactionally.
This makes it possible to do pop-free routing changes in the graph.