### PR TITLE
Add dependency tracking ref counter implementation...

### DIFF
--- a/haskwrap/include/refcounter.h
+++ b/haskwrap/include/refcounter.h
@@ -1,0 +1,8 @@
+#pragma once
+
+typedef void (*rage_hs_Deallocator)(void *);
+typedef struct rage_hs_RefCount rage_hs_RefCount;
+
+rage_hs_RefCount * rage_hs_count_ref(rage_hs_Deallocator dealloc, void * ref);
+void rage_hs_depend_ref(rage_hs_RefCount * depender, rage_hs_RefCount * dependee);
+void rage_hs_decrement_ref(rage_hs_RefCount * ref);

--- a/haskwrap/src/refcounter.c
+++ b/haskwrap/src/refcounter.c
@@ -1,0 +1,46 @@
+#include <stdlib.h>
+#include "refcounter.h"
+
+typedef struct rage_hs_RefCountList rage_hs_RefCountList;
+
+struct rage_hs_RefCount {
+    unsigned count;
+    void * ref;
+    rage_hs_Deallocator dealloc;
+    rage_hs_RefCountList * reqs;
+};
+
+struct rage_hs_RefCountList {
+    rage_hs_RefCountList * next;
+    rage_hs_RefCount * rc;
+};
+
+rage_hs_RefCount * rage_hs_count_ref(rage_hs_Deallocator dealloc, void * ref) {
+    rage_hs_RefCount * new_ref = malloc(sizeof(rage_hs_RefCount));
+    new_ref->count = 1;
+    new_ref->ref = ref;
+    new_ref->dealloc = dealloc;
+    new_ref->reqs = NULL;
+    return new_ref;
+}
+
+void rage_hs_depend_ref(rage_hs_RefCount * depender, rage_hs_RefCount * dependee) {
+    dependee->count++;
+    rage_hs_RefCountList * newl = malloc(sizeof(rage_hs_RefCountList));
+    newl->next = depender->reqs;
+    depender->reqs = newl;
+    newl->rc = dependee;
+}
+
+void rage_hs_decrement_ref(rage_hs_RefCount * ref) {
+    if (--ref->count == 0) {
+        ref->dealloc(ref->ref);
+        while (ref->reqs) {
+            rage_hs_decrement_ref(ref->reqs->rc);
+            rage_hs_RefCountList * next = ref->reqs->next;
+            free(ref->reqs);
+            ref->reqs = next;
+        }
+        free(ref);
+    }
+}

--- a/haskwrap/test/test_refcounter.c
+++ b/haskwrap/test/test_refcounter.c
@@ -1,0 +1,24 @@
+#include "testing.h"
+#include "refcounter.h"
+
+static void sub1(int * i) {
+    (*i)--;
+}
+
+static rage_Error test_refcounter() {
+    int a = 1, b = 1;
+    rage_hs_RefCount * ra = rage_hs_count_ref((rage_hs_Deallocator) sub1, &a);
+    rage_hs_RefCount * rb = rage_hs_count_ref((rage_hs_Deallocator) sub1, &b);
+    rage_hs_depend_ref(rb, ra);
+    rage_hs_decrement_ref(ra);
+    if (a != 1 || b != 1) {
+        return RAGE_ERROR("deallocator invoked early");
+    }
+    rage_hs_decrement_ref(rb);
+    if (a || b) {
+        return RAGE_ERROR("deallocator not invoked");
+    }
+    return RAGE_OK;
+}
+
+TEST_MAIN(test_refcounter)

--- a/meson.build
+++ b/meson.build
@@ -145,7 +145,7 @@ example = executable(
 
 # Haskell wrapper (because you can't return structs to GHC)
 
-hsw_sources = ['haskwrap/src/wrappers.c']
+hsw_sources = ['haskwrap/src/wrappers.c', 'haskwrap/src/refcounter.c']
 hsw_inc = include_directories('haskwrap/include/')
 hsw = library(
     'rage_hswrap',
@@ -153,3 +153,9 @@ hsw = library(
     include_directories: [graph_inc, types_inc, langext_inc, hsw_inc],
     link_with: [rage_graph],
     install: true)
+test_hsw = executable(
+    'test_haskwrap',
+    ['haskwrap/test/test_refcounter.c'],
+    include_directories: [langext_inc, hsw_inc],
+    link_with: [langext, hsw])
+test('haskwrap', test_hsw)


### PR DESCRIPTION
the idea being to use this in the haskell wrappers to make the free
order stop mattering and allow us to use the finalisers from haskell's
FFI.